### PR TITLE
Remove usage of flow in our linter

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,6 @@ module.exports = {
         'plugin:jest/recommended',
         'plugin:promise/recommended',
         'prettier',
-        'prettier/flowtype',
         'prettier/react',
     ],
     parserOptions: {
@@ -25,17 +24,12 @@ module.exports = {
         'import',
         'jest',
         'promise',
-        'flowtype-errors',
-        'flowtype',
         'prettier',
     ],
     settings: {
         'import/internal-module-folders': ['~/'],
         'import/resolver': {
             'babel-module': {},
-        },
-        flowtype: {
-            onlyFilesWithFlowAnnotation: true,
         },
     },
     overrides: [
@@ -306,36 +300,6 @@ module.exports = {
             ],
             'newlines-between': 'always',
         }],
-
-
-        //
-        // eslint-plugin-flowtype
-        //
-        // flowtype specific linting rules for ESLint
-        //
-        'flowtype/boolean-style': ['error', 'boolean'],
-        'flowtype/define-flow-type': 'warn',
-        'flowtype/no-dupe-keys': 'error',
-        'flowtype/no-primitive-constructor-types': 'off',
-        'flowtype/no-types-missing-file-annotation': 'error',
-        'flowtype/no-weak-types': 'off',
-        'flowtype/require-parameter-type': 'off',
-        'flowtype/require-return-type': 'warn',
-        'flowtype/require-valid-file-annotation': ['warn', 'never', { annotationStyle: 'line' }],
-        'flowtype/require-variable-type': 'off',
-        'flowtype/sort-keys': 'off',
-        'flowtype/type-id-match': 'warn',
-        'flowtype/use-flow-type': 'warn',
-        'flowtype/valid-syntax': 'warn',
-
-        //
-        // eslint-plugin-flowtype-errors
-        //
-        // flowtype-errors specific linting rules for ESLint
-        //
-        'flowtype-errors/show-errors': 'warn',
-
-
         //
         // eslint-plugin-prettier
         //

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-fictiv",
-  "version": "11.0.0",
+  "version": "12.0.0",
   "description": "Fictiv's JS linter style",
   "main": "index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -28,8 +28,6 @@
     "babel-eslint": "^10.0.3",
     "eslint-config-prettier": "^6.3.0",
     "eslint-plugin-babel": "^5.3.0",
-    "eslint-plugin-flowtype": "^4.3.0",
-    "eslint-plugin-flowtype-errors": "^4.1.0",
     "eslint-plugin-import": "whoaa512/eslint-plugin-import#9a4b8fb741903c4292e74db120c20afc0ddd28ac",
     "eslint-plugin-jest": "^22.17.0",
     "eslint-plugin-prettier": "^3.1.1",
@@ -40,7 +38,6 @@
   },
   "devDependencies": {
     "eslint": ">=4.2.0",
-    "flow-bin": ">=0.36.0",
     "prettier": "^1.18.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -56,13 +56,6 @@
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.6.2.tgz#205e9c95e16ba3b8b96090677a67c9d6075b70a1"
   integrity sha512-mdFqWrSPCmikBoaBYMuBulzTIKuXVPtEISFbRRVNwMWpCms/hmE2kRq0bblUHaNRKrjRlmVbx1sDHmjmRgD2Xg==
 
-"@babel/runtime@^7.4.2":
-  version "7.6.2"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.6.2.tgz#c3d6e41b304ef10dcf13777a33e7694ec4a9a6dd"
-  integrity sha512-EXxN64agfUqqIGeEjI5dL5z0Sw0ZwWo1mLTi4mQowCZ42O59b7DRpZAnTC6OqdF28wMBMFKNb/4uFGrVaigSpg==
-  dependencies:
-    regenerator-runtime "^0.13.2"
-
 "@babel/template@^7.1.0":
   version "7.6.0"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.6.0.tgz#7f0159c7f5012230dad64cca42ec9bdb5c9536e6"
@@ -630,22 +623,6 @@ eslint-plugin-babel@^5.3.0:
   dependencies:
     eslint-rule-composer "^0.3.0"
 
-eslint-plugin-flowtype-errors@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-flowtype-errors/-/eslint-plugin-flowtype-errors-4.1.0.tgz#6edb0837001f70001ceeb33f0541bd2b8eb8e6c8"
-  integrity sha512-79Hy4ITWwXF7J8/N7jZG6PN6O+kL8oUCZgQaPf4eT8UvSI0x10WACEDzfxJgG1qW3/FN/lT6U1e7K/7fpIWPKw==
-  dependencies:
-    "@babel/runtime" "^7.4.2"
-    find-up "^3.0.0"
-    slash "^2.0.0"
-
-eslint-plugin-flowtype@^4.3.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-flowtype/-/eslint-plugin-flowtype-4.3.0.tgz#06d0837ac341caf369e7e6dbb112dd7fd21acf17"
-  integrity sha512-elvqoadMHnYqSYN1YXn02DR7SFW8Kc2CLe8na3m2GdQPQhIY+BgCd2quVJ1AbW3aO0zcyE9loVJ7Szy8A/xlMA==
-  dependencies:
-    lodash "^4.17.15"
-
 eslint-plugin-import@whoaa512/eslint-plugin-import#9a4b8fb741903c4292e74db120c20afc0ddd28ac:
   version "2.18.0"
   resolved "https://codeload.github.com/whoaa512/eslint-plugin-import/tar.gz/9a4b8fb741903c4292e74db120c20afc0ddd28ac"
@@ -966,10 +943,6 @@ flatted@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.1.tgz#69e57caa8f0eacbc281d2e2cb458d46fdb449e08"
   integrity sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==
-
-flow-bin@>=0.36.0:
-  version "0.53.1"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.53.1.tgz#9b22b63a23c99763ae533ebbab07f88c88c97d84"
 
 foreach@^2.0.5:
   version "2.0.5"
@@ -1368,7 +1341,7 @@ lodash@^4.17.11, lodash@^4.17.4, lodash@^4.3.0:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
 
-lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15:
+lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
@@ -1813,11 +1786,6 @@ regenerator-runtime@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz#7e54fe5b5ccd5d6624ea6255c3473be090b802e1"
 
-regenerator-runtime@^0.13.2:
-  version "0.13.3"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz#7cf6a77d8f5c6f60eb73c5fc1955b2ceb01e6bf5"
-  integrity sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==
-
 regexpp@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-2.0.1.tgz#8d19d31cf632482b589049f8281f93dbcba4d07f"
@@ -1945,11 +1913,6 @@ shebang-regex@^1.0.0:
 signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
-
-slash@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/slash/-/slash-2.0.0.tgz#de552851a1759df3a8f206535442f5ec4ddeab44"
-  integrity sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==
 
 slice-ansi@1.0.0:
   version "1.0.0"


### PR DESCRIPTION
### Summary
The apis and fictiv-js repo are the only repos that use this shared config but they are both converting to typeScript. This commit removes all the usage of flow in our linter

